### PR TITLE
Clarify deployment workflow usage and allow dry runs

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -9,6 +9,7 @@ on:
       - main
     paths:
       - "client/**"
+  workflow_call:
 
 jobs:
   build_and_test_client:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,101 @@
+name: Test, Build & Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      deploy_api:
+        description: Deploy the API to the configured Azure Web App
+        type: boolean
+        default: true
+      deploy_client:
+        description: Deploy the React client to GitHub Pages
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  backend_ci:
+    uses: ./.github/workflows/dotnet-ci.yml
+    secrets:
+      SQL_SA_PASSWORD: ${{ secrets.SQL_SA_PASSWORD }}
+
+  frontend_ci:
+    uses: ./.github/workflows/client-ci.yml
+
+  deploy_api:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.deploy_api == 'true'
+    needs:
+      - backend_ci
+      - frontend_ci
+    runs-on: ubuntu-latest
+    environment:
+      name: production-api
+      url: ${{ steps.deploy.outputs.webapp-url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Publish API
+        run: dotnet publish src/Notes.API/Notes.API.csproj -c Release -o publish
+
+      - name: Deploy API to Azure Web App
+        id: deploy
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: publish
+
+  deploy_client:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.deploy_client == 'true'
+    needs:
+      - backend_ci
+      - frontend_ci
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        working-directory: client
+        run: npm ci
+
+      - name: Build client
+        working-directory: client
+        run: npm run build
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload static site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: client/build
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -11,6 +11,10 @@ on:
       - "**/*.cs"
       - "**/*.csproj"
       - "**/*.sln"
+  workflow_call:
+    secrets:
+      SQL_SA_PASSWORD:
+        required: true
 
 jobs:
   build_and_test:

--- a/README.md
+++ b/README.md
@@ -28,3 +28,29 @@ dotnet run --project src/Notes.API
 ```
 
 By default the application listens on `https://localhost:7098` and `http://localhost:5145`. Use the `/notes` endpoints to create, read, update and delete notes.
+
+## CI/CD workflows
+
+The repository ships with reusable client and API pipelines plus a combined orchestration workflow (`.github/workflows/deploy.yml`).
+
+* `client-ci.yml` builds and tests the React single-page application under `client/`.
+* `dotnet-ci.yml` restores, builds and tests the .NET API.
+* `deploy.yml` runs both CI workflows and, when requested, deploys the API to Azure App Service and the client to GitHub Pages.
+
+### Running the deployment workflow safely
+
+The deployment workflow runs automatically on pushes to `main`, but you can trigger it manually from the **Actions** tab using the **Run workflow** button. Manual runs expose two checkboxes:
+
+* **Deploy the API to the configured Azure Web App**
+* **Deploy the React client to GitHub Pages**
+
+Disable either option to perform a dry run that only executes the tests and builds. This makes it easy to validate the pipeline from a feature branch without publishing new artifacts.
+
+### Required secrets and hosting options
+
+To publish successfully you must configure the following repository secrets:
+
+* `SQL_SA_PASSWORD` – reused by the backend CI workflow for integration tests.
+* `AZURE_WEBAPP_NAME` and `AZURE_WEBAPP_PUBLISH_PROFILE` – credentials for the Azure App Service instance that will host the API.
+
+GitHub Pages covers the static SPA hosting for free. GitHub itself does not provide free hosting for .NET APIs, but the Azure App Service free tier works well with the included workflow. You can also adapt the deployment job to target other providers (for example, Azure Container Apps, Render, Fly.io) by replacing the `azure/webapps-deploy` step with the provider’s recommended GitHub Action.


### PR DESCRIPTION
## Summary
- add manual run inputs to the combined deployment workflow so it can run in dry-run mode
- document how the CI/CD workflows interact and which secrets are required, plus backend hosting options

## Testing
- not run (documentation and workflow definition changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125f3c4018833381388b3409ab79fa)